### PR TITLE
fix: correct score annotation namespace

### DIFF
--- a/score-workload/kubernetes/main.tf
+++ b/score-workload/kubernetes/main.tf
@@ -16,7 +16,7 @@ resource "random_id" "id" {
 }
 
 locals {
-  workload_type = lookup(coalesce(try(var.metadata.annotations, null), {}), "score.canyon.com/workload-type", "Deployment")
+  workload_type = lookup(coalesce(try(var.metadata.annotations, null), {}), "score.humanitec.dev/workload-type", "Deployment")
   pod_labels    = { app = random_id.id.hex }
   # Create a map of all secret data, keyed by a stable identifier
   all_secret_data = merge(


### PR DESCRIPTION
Leftover from canyon. Needs to be changed over to humanitec.