### PR TITLE
feat: added simple score-workload/aws-lambda sample

### DIFF
--- a/score-workload/aws-lambda/README.md
+++ b/score-workload/aws-lambda/README.md
@@ -24,28 +24,21 @@ hctl create module \
 
 The following outputs are exposed
 
-| Name            | Description                                                            | Type     |
-| --------------- | ---------------------------------------------------------------------- | -------- |
-| `endpoint`      | The dns name of the function invoke url if service ports was not empty | `string` |
-| `function_arn`  | The lambda function ARN                                                | `string` |
+| Name           | Description                                                            | Type     |
+| -------------- | ---------------------------------------------------------------------- | -------- |
+| `endpoint`     | The dns name of the function invoke url if service ports was not empty | `string` |
+| `function_arn` | The lambda function ARN                                                | `string` |
+| `iam_role_arn` | The ARN of the IAM role associated with the Function.                  | `string` |
 
 ## Module Inputs
 
 The following input variables can be set in the `module_inputs` of the `hctl create module` command.
 
-| Name                     | Description                                           | Type          | Default | Required |
-| ------------------------ | ----------------------------------------------------- | ------------- | ------- | -------- |
-| `namespace`              | The namespace to deploy to.                           | `string`      |         | yes      |
-| `service_account_name`   | The name of the service account to use for the pods.  | `string`      | `null`  | no       |
-| `additional_annotations` | Additional annotations to add to all resources.       | `map(string)` | `{}`    | no       |
-| `wait_for_rollout`       | Whether to wait for the workload to be rolled out.    | `bool`        | `true`  | no       |
-| `wait_for_timeout`       | Timeout to wait                                       | `string`      | `"1m"`  | no       |
-| `replicas`               | Optional number of replicas to deploy.                | `number`      | `null`  | no       |
-
-For example, to set the `service_account_name` and disable `wait_for_rollout`, you would use:
-
-```shell
-hctl create module \
-    ...
-    --set=module_inputs='{"namespace": "my-namespace", "service_account_name": "my-sa", "wait_for_rollout": false}'
-```
+| Name                    | Description                                                                        | Type           | Default | Required |
+| ----------------------- | ---------------------------------------------------------------------------------- | -------------- | ------- | -------- |
+| `iam_role_arn           | An existing IAM role to use for the Function, one will be created if not provided. | `string`       |         | no       |
+| `architectures`         | The Lambda architecture (x86_64 or arm64). Defaults to x86_64.                     | `list(string)` | `null`  | `no`     |
+| `aws_region`            | The AWS region to deploy the function to. Defaults to the region of the provider.  | `string`       | `null`  | no       |
+| `timeout_in_seconds`    | Timeout of the function.                                                           | `integer`      | `3`     | no       |
+| `is_ecr_policy_enabled` | Whether to create the IAM policy for pulling images from ECR.                      | `bool`         | `true`  | no       |
+| `additional_tags`       | Additional AWS tags to add to AWS resources                                        | `map(string)`  | `{}`    | no       |

--- a/score-workload/aws-lambda/README.md
+++ b/score-workload/aws-lambda/README.md
@@ -36,7 +36,7 @@ The following input variables can be set in the `module_inputs` of the `hctl cre
 
 | Name                    | Description                                                                        | Type           | Default | Required |
 | ----------------------- | ---------------------------------------------------------------------------------- | -------------- | ------- | -------- |
-| `iam_role_arn           | An existing IAM role to use for the Function, one will be created if not provided. | `string`       |         | no       |
+| `iam_role_arn`          | An existing IAM role to use for the Function, one will be created if not provided. | `string`       |         | no       |
 | `architectures`         | The Lambda architecture (x86_64 or arm64). Defaults to x86_64.                     | `list(string)` | `null`  | `no`     |
 | `aws_region`            | The AWS region to deploy the function to. Defaults to the region of the provider.  | `string`       | `null`  | no       |
 | `timeout_in_seconds`    | Timeout of the function.                                                           | `integer`      | `3`     | no       |

--- a/score-workload/aws-lambda/README.md
+++ b/score-workload/aws-lambda/README.md
@@ -24,9 +24,10 @@ hctl create module \
 
 The following outputs are exposed
 
-| Name            | Description                                             | Type     |
-| --------------- | ------------------------------------------------------- | -------- |
-| `endpoint`      | The dns name of the clusterip service for this workload | `string` |
+| Name            | Description                                                            | Type     |
+| --------------- | ---------------------------------------------------------------------- | -------- |
+| `endpoint`      | The dns name of the function invoke url if service ports was not empty | `string` |
+| `function_arn`  | The lambda function ARN                                                | `string` |
 
 ## Module Inputs
 

--- a/score-workload/aws-lambda/README.md
+++ b/score-workload/aws-lambda/README.md
@@ -37,8 +37,8 @@ The following input variables can be set in the `module_inputs` of the `hctl cre
 | Name                    | Description                                                                        | Type           | Default | Required |
 | ----------------------- | ---------------------------------------------------------------------------------- | -------------- | ------- | -------- |
 | `iam_role_arn`          | An existing IAM role to use for the Function, one will be created if not provided. | `string`       |         | no       |
-| `architectures`         | The Lambda architecture (x86_64 or arm64). Defaults to x86_64.                     | `list(string)` | `null`  | `no`     |
-| `aws_region`            | The AWS region to deploy the function to. Defaults to the region of the provider.  | `string`       | `null`  | no       |
+| `architectures`         | The Lambda architecture (x86_64 or arm64). Defaults to x86_64.                     | `list(string)` |         | no       |
+| `aws_region`            | The AWS region to deploy the function to. Defaults to the region of the provider.  | `string`       |         | no       |
 | `timeout_in_seconds`    | Timeout of the function.                                                           | `integer`      | `3`     | no       |
 | `is_ecr_policy_enabled` | Whether to create the IAM policy for pulling images from ECR.                      | `bool`         | `true`  | no       |
 | `additional_tags`       | Additional AWS tags to add to AWS resources                                        | `map(string)`  | `{}`    | no       |

--- a/score-workload/aws-lambda/README.md
+++ b/score-workload/aws-lambda/README.md
@@ -9,7 +9,7 @@ This is a Terraform / OpenTofu compatible module to be used to provision `score-
 
 ## Installation
 
-Install this with the `hctl` CLI, you should replace the `CHANGEME` in the provider mapping with your real provider type and alias for AWS; and replace the CHANGEME in module_inputs with the real target namespace.
+Install this with the `hctl` CLI, you should replace the `CHANGEME` in the provider mapping with your real provider type and alias for AWS.
 
 ```shell
 hctl create module \
@@ -17,7 +17,7 @@ hctl create module \
     --set=module_source=git::https://github.com/humanitec/module-definition-library//score-workload/aws-lambda \
     --set=provider_mapping='{"aws": "CHANGEME"}' \
     --set=module_params='{"metadata": {"type": "map"},"containers": {"type": "map"}, "service": {"type": "map", "is_optional": true}}' \
-    --set=module_inputs='{"namespace": "CHANGEME"}'
+    --set=module_inputs='{}'
 ```
 
 ## Resource Outputs

--- a/score-workload/aws-lambda/README.md
+++ b/score-workload/aws-lambda/README.md
@@ -1,21 +1,21 @@
-# score-workload/kubernetes
+# score-workload/aws-lambda
 
-This is a Terraform / OpenTofu compatible module to be used to provision `score-workload` resources ontop of Kubernetes for the Humanitec Orchestrator.
+This is a Terraform / OpenTofu compatible module to be used to provision `score-workload` resources ontop of AWS Lambda container functions.
 
 ## Requirements
 
-1. There must be a module provider setup for `kubernetes` (`hashicorp/kubernetes`).
+1. There must be a module provider setup for `aws` (`hashicorp/aws`).
 2. There must be a resource type setup for `score-workload`, see [README](../README.md).
 
 ## Installation
 
-Install this with the `hctl` CLI, you should replace the `CHANGEME` in the provider mapping with your real provider type and alias for Kubernetes; and replace the CHANGEME in module_inputs with the real target namespace.
+Install this with the `hctl` CLI, you should replace the `CHANGEME` in the provider mapping with your real provider type and alias for AWS; and replace the CHANGEME in module_inputs with the real target namespace.
 
 ```shell
 hctl create module \
     --set=resource_type=score-workload \
-    --set=module_source=git::https://github.com/humanitec/module-definition-library//score-workload/kubernetes \
-    --set=provider_mapping='{"kubernetes": "CHANGEME"}' \
+    --set=module_source=git::https://github.com/humanitec/module-definition-library//score-workload/aws-lambda \
+    --set=provider_mapping='{"aws": "CHANGEME"}' \
     --set=module_params='{"metadata": {"type": "map"},"containers": {"type": "map"}, "service": {"type": "map", "is_optional": true}}' \
     --set=module_inputs='{"namespace": "CHANGEME"}'
 ```
@@ -48,20 +48,3 @@ hctl create module \
     ...
     --set=module_inputs='{"namespace": "my-namespace", "service_account_name": "my-sa", "wait_for_rollout": false}'
 ```
-
-### Dynamic namespaces
-
-Instead of a hardcoded destination namespace, you can use the resource graph to provision a namespace.
-
-1. Ensure there is a resource type for the namespace (eg: `k8s-namespace`) and that there is a definition and rule set up for it in the target environments.
-2. Add a dependency to the create module definition request:
-
-    ```
-    --set=dependencies='{"ns": {"type": "k8s-namespace"}}'
-    ```
-
-3. In the module inputs replace this with the placeholder:
-
-    ```
-    --set=module_inputs='{"namespace": "${ resources.ns.outputs.name }"}'
-    ```

--- a/score-workload/aws-lambda/main.tf
+++ b/score-workload/aws-lambda/main.tf
@@ -87,11 +87,12 @@ resource "aws_lambda_function" "container_function" {
 
   architectures = var.architectures
 
+  timeout     = var.timeout
   memory_size = local.memory_size
 }
 
 resource "aws_lambda_function_url" "container_function_url" {
   count              = local.has_service ? 1 : 0
   function_name      = aws_lambda_function.container_function.function_name
-  authorization_type = "AWS_IAM"
+  authorization_type = lookup(coalesce(try(var.metadata.annotations, null), {}), "score.humanitec.dev/function-invoke-authorization", "AWS_IAM")
 }

--- a/score-workload/aws-lambda/main.tf
+++ b/score-workload/aws-lambda/main.tf
@@ -26,32 +26,28 @@ resource "aws_iam_role" "role" {
       }
     ]
   })
+  tags = var.additional_tags
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_basic" {
-  count      = var.iam_role_arn == null ? 1 : 0
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role       = aws_iam_role.role[0].name
+  role       = var.iam_role_arn == null ? aws_iam_role.role[0].name : var.iam_role_arn
 }
 
 resource "aws_iam_role_policy" "ecr" {
-  count = var.iam_role_arn == null ? 1 : 0
+  count = var.iam_role_arn == null && var.is_ecr_policy_enabled ? 1 : 0
   role  = aws_iam_role.role[0].id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Resource = "arn:aws:ecr:eu-central-1:667740703053:repository/*"
+        Effect = "Allow"
         Action = [
           "ecr:GetDownloadUrlForLayer",
           "ecr:BatchGetImage",
           "ecr:BatchCheckLayerAvailability",
+          "ecr:GetAuthorizationToken",
         ]
-      },
-      {
-        Effect   = "Allow"
-        Action   = "ecr:GetAuthorizationToken"
         Resource = "*"
       }
     ]
@@ -73,6 +69,7 @@ locals {
 resource "aws_lambda_function" "container_function" {
   function_name = "score-workload-${random_id.entropy.hex}"
   role          = var.iam_role_arn != null ? var.iam_role_arn : aws_iam_role.role[0].arn
+  region        = var.aws_region
 
   package_type = "Image"
   image_uri    = var.containers.main.image
@@ -87,8 +84,10 @@ resource "aws_lambda_function" "container_function" {
 
   architectures = var.architectures
 
-  timeout     = var.timeout
+  timeout     = var.timeout_in_seconds
   memory_size = local.memory_size
+
+  tags = var.additional_tags
 }
 
 resource "aws_lambda_function_url" "container_function_url" {

--- a/score-workload/aws-lambda/main.tf
+++ b/score-workload/aws-lambda/main.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+resource "aws_iam_role" "role" {
+  count       = var.iam_role_arn == null ? 1 : 0
+  name_prefix = "lambda-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic" {
+  count      = var.iam_role_arn == null ? 1 : 0
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = aws_iam_role.role[0].name
+}
+
+resource "aws_iam_role_policy" "ecr" {
+  count = var.iam_role_arn == null ? 1 : 0
+  role  = aws_iam_role.role[0].id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Resource = "arn:aws:ecr:eu-central-1:667740703053:repository/*"
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability",
+        ]
+      },
+      {
+        Effect   = "Allow"
+        Action   = "ecr:GetAuthorizationToken"
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "random_id" "entropy" {
+  byte_length = 4
+}
+
+locals {
+  has_service = try(length(var.service.ports), 0) > 0
+
+  parts = regex("(\\d+)([MG])$", var.containers.main.resources.limits.memory)
+
+  memory_size = local.parts[1] == "G" ? tonumber(local.parts[0]) * 1000 : tonumber((local.parts[0]))
+}
+
+resource "aws_lambda_function" "container_function" {
+  function_name = "score-workload-${random_id.entropy.hex}"
+  role          = var.iam_role_arn != null ? var.iam_role_arn : aws_iam_role.role[0].arn
+
+  package_type = "Image"
+  image_uri    = var.containers.main.image
+  image_config {
+    entry_point = var.containers.main.command
+    command     = var.containers.main.args
+  }
+
+  environment {
+    variables = var.containers.main.variables
+  }
+
+  architectures = var.architectures
+
+  memory_size = local.memory_size
+}
+
+resource "aws_lambda_function_url" "container_function_url" {
+  count              = local.has_service ? 1 : 0
+  function_name      = aws_lambda_function.container_function.function_name
+  authorization_type = "AWS_IAM"
+}

--- a/score-workload/aws-lambda/outputs.tf
+++ b/score-workload/aws-lambda/outputs.tf
@@ -1,5 +1,5 @@
 locals {
-  endpoint = local.has_service ? aws_lambda_function_url.container_function_url[0].function_url : ""
+  endpoint = local.has_service ? aws_lambda_function_url.container_function_url[0].function_url : "undefined"
 }
 
 output "endpoint" {
@@ -8,6 +8,10 @@ output "endpoint" {
 
 output "function_arn" {
   value = aws_lambda_function.container_function.arn
+}
+
+output "iam_role_arn" {
+  value = var.iam_role_arn == null ? aws_iam_role.role[0].name : var.iam_role_arn
 }
 
 output "humanitec_metadata" {

--- a/score-workload/aws-lambda/outputs.tf
+++ b/score-workload/aws-lambda/outputs.tf
@@ -1,0 +1,19 @@
+locals {
+  endpoint = local.has_service ? aws_lambda_function_url.container_function_url[0].function_url : ""
+}
+
+output "endpoint" {
+  value = local.endpoint
+}
+
+output "function_arn" {
+  value = aws_lambda_function.container_function.arn
+}
+
+output "humanitec_metadata" {
+  value = {
+    Region      = aws_lambda_function.container_function.region
+    Console-Url = "https://${aws_lambda_function.container_function.region}.console.aws.amazon.com/lambda/home?region=${aws_lambda_function.container_function.region}#/functions/${aws_lambda_function.container_function.function_name}"
+    Web-Url     = local.endpoint
+  }
+}

--- a/score-workload/aws-lambda/tests/full.tftest.hcl
+++ b/score-workload/aws-lambda/tests/full.tftest.hcl
@@ -1,0 +1,63 @@
+mock_provider "aws" {
+    mock_resource "aws_iam_role" {
+      defaults = {
+        arn = "arn:aws:iam::123456789012:role/lambda-role"
+      }
+    }
+}
+
+mock_provider "random" {
+    mock_resource "random_id" {
+        defaults = {
+          hex = "abcdef"
+        }
+    }
+}
+
+run "plan" {
+  variables {
+    metadata = {
+      name = "deployment-sparse"
+    }
+
+    containers = {
+      "main" = {
+        image = "nginx:latest"
+        command = ["/bin/sh"]
+        args = ["-c", "echo"]
+        variables = {
+          A = "B"
+        }
+        resources = {
+            limits = {
+                memory = "128M"
+            }
+        }
+      }
+    }
+
+    service = {
+      ports = {
+        invoke = {
+          port = 80
+        }
+      }
+    }
+
+    region = "us-east-1"
+    iam_role_arn = "arn:aws:iam::123456789012:role/custom-role"
+    architectures = ["arm64"]
+  }
+
+  command = plan
+
+  assert {
+    condition = length(tolist(aws_iam_role.role)) == 0
+    error_message = "expected no iam role to be generated"
+  }
+
+  assert {
+    condition = length(tolist(aws_lambda_function_url.container_function_url)) > 0
+    error_message = "expected a function url"
+  }
+}

--- a/score-workload/aws-lambda/tests/full.tftest.hcl
+++ b/score-workload/aws-lambda/tests/full.tftest.hcl
@@ -1,17 +1,17 @@
 mock_provider "aws" {
-    mock_resource "aws_iam_role" {
-      defaults = {
-        arn = "arn:aws:iam::123456789012:role/lambda-role"
-      }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/lambda-role"
     }
+  }
 }
 
 mock_provider "random" {
-    mock_resource "random_id" {
-        defaults = {
-          hex = "abcdef"
-        }
+  mock_resource "random_id" {
+    defaults = {
+      hex = "abcdef"
     }
+  }
 }
 
 run "plan" {
@@ -22,16 +22,16 @@ run "plan" {
 
     containers = {
       "main" = {
-        image = "nginx:latest"
+        image   = "nginx:latest"
         command = ["/bin/sh"]
-        args = ["-c", "echo"]
+        args    = ["-c", "echo"]
         variables = {
           A = "B"
         }
         resources = {
-            limits = {
-                memory = "128M"
-            }
+          limits = {
+            memory = "128M"
+          }
         }
       }
     }
@@ -44,20 +44,30 @@ run "plan" {
       }
     }
 
-    region = "us-east-1"
-    iam_role_arn = "arn:aws:iam::123456789012:role/custom-role"
-    architectures = ["arm64"]
+    aws_region            = "us-east-1"
+    iam_role_arn          = "arn:aws:iam::123456789012:role/custom-role"
+    architectures         = ["arm64"]
+    timeout_in_seconds    = 10
+    is_ecr_policy_enabled = false
+    additional_labels = {
+      "A" : "B",
+    }
   }
 
   command = plan
 
   assert {
-    condition = length(tolist(aws_iam_role.role)) == 0
+    condition     = length(tolist(aws_iam_role.role)) == 0
     error_message = "expected no iam role to be generated"
   }
 
   assert {
-    condition = length(tolist(aws_lambda_function_url.container_function_url)) > 0
+    condition     = can(aws_iam_role_policy_attachment.lambda_basic.role)
+    error_message = "expected an lambda_basic policy to be generated"
+  }
+
+  assert {
+    condition     = can(aws_lambda_function_url.container_function_url[0])
     error_message = "expected a function url"
   }
 }

--- a/score-workload/aws-lambda/tests/tiny.tftest.hcl
+++ b/score-workload/aws-lambda/tests/tiny.tftest.hcl
@@ -1,17 +1,17 @@
 mock_provider "aws" {
-    mock_resource "aws_iam_role" {
-      defaults = {
-        arn = "arn:aws:iam::123456789012:role/lambda-role"
-      }
+  mock_resource "aws_iam_role" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:role/lambda-role"
     }
+  }
 }
 
 mock_provider "random" {
-    mock_resource "random_id" {
-        defaults = {
-          hex = "abcdef"
-        }
+  mock_resource "random_id" {
+    defaults = {
+      hex = "abcdef"
     }
+  }
 }
 
 run "plan" {
@@ -24,9 +24,9 @@ run "plan" {
       "main" = {
         image = "nginx:latest"
         resources = {
-            limits = {
-                memory = "128M"
-            }
+          limits = {
+            memory = "128M"
+          }
         }
       }
     }
@@ -35,12 +35,22 @@ run "plan" {
   command = plan
 
   assert {
-    condition = length(tolist(aws_iam_role.role)) > 0
+    condition     = can(aws_iam_role.role[0])
     error_message = "expected an iam role to be generated"
   }
 
   assert {
-    condition = length(tolist(aws_lambda_function_url.container_function_url)) == 0
+    condition     = can(aws_iam_role_policy_attachment.lambda_basic.role)
+    error_message = "expected an lambda_basic policy to be generated"
+  }
+
+  assert {
+    condition     = can(aws_iam_role_policy.ecr[0])
+    error_message = "expected an ecr policy to be generated"
+  }
+
+  assert {
+    condition     = length(tolist(aws_lambda_function_url.container_function_url)) == 0
     error_message = "expected no function url"
   }
 }

--- a/score-workload/aws-lambda/tests/tiny.tftest.hcl
+++ b/score-workload/aws-lambda/tests/tiny.tftest.hcl
@@ -1,0 +1,46 @@
+mock_provider "aws" {
+    mock_resource "aws_iam_role" {
+      defaults = {
+        arn = "arn:aws:iam::123456789012:role/lambda-role"
+      }
+    }
+}
+
+mock_provider "random" {
+    mock_resource "random_id" {
+        defaults = {
+          hex = "abcdef"
+        }
+    }
+}
+
+run "plan" {
+  variables {
+    metadata = {
+      name = "deployment-sparse"
+    }
+
+    containers = {
+      "main" = {
+        image = "nginx:latest"
+        resources = {
+            limits = {
+                memory = "128M"
+            }
+        }
+      }
+    }
+  }
+
+  command = plan
+
+  assert {
+    condition = length(tolist(aws_iam_role.role)) > 0
+    error_message = "expected an iam role to be generated"
+  }
+
+  assert {
+    condition = length(tolist(aws_lambda_function_url.container_function_url)) == 0
+    error_message = "expected no function url"
+  }
+}

--- a/score-workload/aws-lambda/variables.tf
+++ b/score-workload/aws-lambda/variables.tf
@@ -1,0 +1,54 @@
+variable "metadata" {
+  type        = any
+  description = "The metadata section of the Score file."
+}
+
+variable "containers" {
+  type = object({
+    main = object({
+      image     = string
+      command   = optional(list(string))
+      args      = optional(list(string))
+      variables = optional(map(string))
+      resources = object({
+        limits = object({
+          memory = string
+        })
+      })
+    })
+  })
+  description = "The containers section of the Score file, expecting just a single container called 'main'"
+
+  validation {
+    condition     = regex("^\\d+[MG]$", var.containers.main.resources.limits.memory) != null
+    error_message = "memory limit must end in either M or G"
+  }
+}
+
+variable "service" {
+  type = object({
+    ports = optional(map(object({
+      port = number
+    })))
+  })
+  description = "The service section of the Score file."
+  default     = null
+}
+
+variable "iam_role_arn" {
+  type        = string
+  description = "An optional IAM role to run the function as. A simple role will be created if this is not supplied"
+  default     = null
+}
+
+variable "architectures" {
+  type        = list(string)
+  description = "Set the AWS Lambda architectures supported by the image"
+  default     = null
+}
+
+variable "region" {
+  type        = string
+  description = "Optional region override otherwise the function will be deployed in the same region as the provider"
+  default     = null
+}

--- a/score-workload/aws-lambda/variables.tf
+++ b/score-workload/aws-lambda/variables.tf
@@ -52,3 +52,9 @@ variable "region" {
   description = "Optional region override otherwise the function will be deployed in the same region as the provider"
   default     = null
 }
+
+variable "timeout" {
+  type        = number
+  description = "The underlying function timeout in seconds"
+  default     = 3
+}

--- a/score-workload/aws-lambda/variables.tf
+++ b/score-workload/aws-lambda/variables.tf
@@ -37,7 +37,7 @@ variable "service" {
 
 variable "iam_role_arn" {
   type        = string
-  description = "An optional IAM role to run the function as. A simple role will be created if this is not supplied"
+  description = "An optional IAM role to run the function as. A role will be created if this is not supplied"
   default     = null
 }
 
@@ -47,14 +47,26 @@ variable "architectures" {
   default     = null
 }
 
-variable "region" {
+variable "aws_region" {
   type        = string
   description = "Optional region override otherwise the function will be deployed in the same region as the provider"
   default     = null
 }
 
-variable "timeout" {
+variable "timeout_in_seconds" {
   type        = number
   description = "The underlying function timeout in seconds"
   default     = 3
+}
+
+variable "is_ecr_policy_enabled" {
+  type        = bool
+  description = "Whether to auto create a policy for ECR access, enabled by default"
+  default     = true
+}
+
+variable "additional_tags" {
+  type        = map(string)
+  description = "A set of additional tags to add to aws resources provisioned by this module"
+  default     = {}
 }


### PR DESCRIPTION
This PR adds a minimum implementation of a score-workload on aws lambda. It supports the following fields:

- one container that must be named `main`
- image, command, and args may be specified
- files are not supported
- volumes are not supported
- resource requests and resource cpu limits are not supported
- service ports are not supported, the only affect is to enable or disable the invoke function url.

This is generally just for testing, and demo purposes. In many cases, it may be better to use a non-Score resource type for AWS Lambda. Or use ECS Fargate instead.

Tested with:

```
resource "platform-orchestrator_module" "lambda" {
  id = "ecs-runner-lambda-module"
  resource_type = platform-orchestrator_resource_type.score.id
  module_source = "git::https://github.com/humanitec/module-definition-library//score-workload/aws-lambda?ref=lambda"
  provider_mapping = {
    aws = "aws.${platform-orchestrator_provider.aws.id}"
  }
  module_params = {
    metadata = {
      type = "map"
    }
    containers = {
      type = "map"
    }
    service = {
      type = "map"
      is_optional = true
    }
  }
  module_inputs = jsonencode({
    aws_region = "eu-central-1"
    additional_tags = {
      Example = "helloworld"
    }
    architectures = ["x86_64"]
    timeout_in_seconds = 10
    is_ecr_policy_enabled = true
  })
}
```

And

```
apiVersion: score.dev/v1b1
metadata:
  name: example
  annotations:
    humanitec.dev/resClass: function
    score.humanitec.dev/function-invoke-authorization: NONE
containers:
  main:
    image: 667740703053.dkr.ecr.eu-central-1.amazonaws.com/bentesting/demo-lambda:v2
    resources:
      limits:
        memory: 1G
service:
  ports:
    invoke:
      port: 80
```
